### PR TITLE
Unit selection

### DIFF
--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -794,7 +794,7 @@ class AnalysesView(ListingView):
         """Render HTML element for unit
         """
         if css_class is None:
-            css_class = "unit d-inline-block py-2 small text-secondary"
+            css_class = "unit d-inline-block py-2 small text-secondary text-nowrap"
         return "<span class='{css_class}'>{unit}</span>".format(
             unit=unit, css_class=css_class)
 
@@ -1077,9 +1077,11 @@ class AnalysesView(ListingView):
                     # Copy to prevent to avoid persistent changes
                     unit_choice_fields = deepcopy(unit_choice_fields)
                     # Get the {value:text} dict
-                    choices=["{}:{}".format(x['unitchoice'],x['unitchoice']) for x in unit_choice_fields]
+                    # Remove leading white space on front of unit choices. 
+                    choices=["{}:{}".format(x['unitchoice'],x['unitchoice'].lstrip()) for x in unit_choice_fields]
                     # Add default unit to list of choices
-                    choices.append("{}:{}".format(unit,unit))
+                    # Space in {}: {} ensures that the default unit is always on top of the selection.
+                    choices.append("{}: {}".format(unit,unit))
                     # Create a dictionary of the choices
                     choices = dict(map(lambda ch: ch.strip().split(":"), choices))
                     # Generate the display list
@@ -1088,6 +1090,7 @@ class AnalysesView(ListingView):
                     dl = map(lambda it: dict(zip(headers, it)), choices.items())
                     item["choices"]["UnitChoices"] = dl
                     item["allow_edit"].append("UnitChoices")
+
 
     def _folder_item_method(self, analysis_brain, item):
         """Fills the analysis' method to the item passed in.

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -1117,7 +1117,9 @@ class AnalysesView(ListingView):
         if unit:
             item["after"]["Result"] = self.render_unit(unit)
 
-        return item    def _on_method_change(self, uid=None, value=None, item=None, **kw):
+        return item    
+    
+    def _on_method_change(self, uid=None, value=None, item=None, **kw):
 
         """Update instrument and calculation when the method changes
 

--- a/src/bika/lims/browser/analyses/view.py
+++ b/src/bika/lims/browser/analyses/view.py
@@ -135,6 +135,12 @@ class AnalysesView(ListingView):
                 "title": _("Calculation"),
                 "sortable": False,
                 "toggle": False}),
+            ("UnitChoices", {
+                "title": _("Unit Selection"),
+                "sortable": False,
+                "ajax": True,
+                "on_change": "_on_unit_choice_change",
+                "toggle": True}),
             ("Analyst", {
                 "title": _("Analyst"),
                 "sortable": False,
@@ -155,12 +161,12 @@ class AnalysesView(ListingView):
                 "input_class": "ajax_calculate numeric",
                 "ajax": True,
                 "sortable": False}),
-            ("Specification", {
-                "title": _("Specification"),
-                "sortable": False}),
             ("Uncertainty", {
                 "title": _("+-"),
                 "ajax": True,
+                "sortable": False}),
+            ("Specification", {
+                "title": _("Specification"),
                 "sortable": False}),
             ("retested", {
                 "title": _("Retested"),
@@ -664,6 +670,8 @@ class AnalysesView(ListingView):
         self._folder_item_result(obj, item)
         # Fill calculation and interim fields
         self._folder_item_calculation(obj, item)
+        # Fill unit choices field
+        self._folder_item_unit_choices(obj, item)        
         # Fill method
         self._folder_item_method(obj, item)
         # Fill instrument
@@ -778,6 +786,7 @@ class AnalysesView(ListingView):
         # analyses requires them to be displayed for selection
         self.columns["Method"]["toggle"] = self.is_method_column_required()
         self.columns["Instrument"]["toggle"] = self.is_instrument_column_required()
+        self.columns["UnitChoices"]["toggle"] = self.is_unit_choices_column_required()
 
         return items
 
@@ -1045,6 +1054,41 @@ class AnalysesView(ListingView):
         item["interimfields"] = interim_fields
         self.interim_fields[analysis_brain.UID] = interim_fields
 
+    def _folder_item_unit_choices(self, analysis_brain, item):
+        """Set the unit choices to the item passed in.
+        :param analysis_brain: Brain that represents an analysis
+        :param item: analysis' dictionary counterpart that represents a row
+        """
+        if not self.has_permission(ViewResults, analysis_brain):
+            # Hide unit_choices if user cannot view results
+            return
+        is_editable = self.is_analysis_edition_allowed(analysis_brain)
+        if is_editable:
+            # Set unit_choices. The default unit is also included. 
+            analysis_obj = self.get_object(analysis_brain)
+            # get unit_choice_fields
+            unit_choice_fields = analysis_obj.getUnitChoices() or list()
+            if unit_choice_fields:
+                # Get the keys for the dictionary
+                unit_choice_fields_key=set().union(*(d.keys() for d in unit_choice_fields))
+                if 'unitchoice' in unit_choice_fields_key:
+                    # Get the default unit
+                    unit=analysis_obj.getUnit()
+                    # Copy to prevent to avoid persistent changes
+                    unit_choice_fields = deepcopy(unit_choice_fields)
+                    # Get the {value:text} dict
+                    choices=["{}:{}".format(x['unitchoice'],x['unitchoice']) for x in unit_choice_fields]
+                    # Add default unit to list of choices
+                    choices.append("{}:{}".format(unit,unit))
+                    # Create a dictionary of the choices
+                    choices = dict(map(lambda ch: ch.strip().split(":"), choices))
+                    # Generate the display list
+                    # [{"ResultValue": value, "ResultText": text},]
+                    headers = ["ResultValue", "ResultText"]
+                    dl = map(lambda it: dict(zip(headers, it)), choices.items())
+                    item["choices"]["UnitChoices"] = dl
+                    item["allow_edit"].append("UnitChoices")
+
     def _folder_item_method(self, analysis_brain, item):
         """Fills the analysis' method to the item passed in.
 
@@ -1065,7 +1109,16 @@ class AnalysesView(ListingView):
                 item["Method"] = api.get_title(method)
                 item["replace"]["Method"] = get_link_for(method, tabindex="-1")
 
-    def _on_method_change(self, uid=None, value=None, item=None, **kw):
+    def _on_unit_choice_change(self, uid=None, value=None, item=None, **kw):
+        """ updates the unit on selection of unit_choices. 
+        """
+        item["Unit"] = value
+        unit = item.get("Unit")
+        if unit:
+            item["after"]["Result"] = self.render_unit(unit)
+
+        return item    def _on_method_change(self, uid=None, value=None, item=None, **kw):
+
         """Update instrument and calculation when the method changes
 
         :param uid: object UID
@@ -1543,6 +1596,16 @@ class AnalysesView(ListingView):
         # a method is selected
         return len(instruments) > 0
 
+    def is_unit_choices_required(self, analysis):
+        """Returns whether the render of the unit choice selection list is
+        required for the analysis passed-in.
+        :param analysis: Brain or object that represents an analysis
+        """
+        # Always return true if the analysis has unitchoices
+        analysis = self.get_object(analysis)
+        if analysis.getUnitChoices():
+            return True
+
     def is_method_column_required(self):
         """Returns whether the method column has to be rendered or not.
         Returns True if at least one of the analyses from the listing requires
@@ -1562,5 +1625,16 @@ class AnalysesView(ListingView):
         for item in self.items:
             obj = item.get("obj")
             if self.is_instrument_required(obj):
+                return True
+        return False
+        
+    def is_unit_choices_column_required(self):
+        """Returns whether the unit_choices column has to be rendered or not.
+        Returns True if at least one of the analyses from the listing requires
+        the list for unit_choices selection to be rendered
+        """
+        for item in self.items:
+            obj = item.get("obj")
+            if self.is_unit_choices_required(obj):
                 return True
         return False

--- a/src/bika/lims/content/abstractbaseanalysis.py
+++ b/src/bika/lims/content/abstractbaseanalysis.py
@@ -103,10 +103,47 @@ Unit = StringField(
     'Unit',
     schemata="Description",
     widget=StringWidget(
-        label=_("Unit"),
+        label=_("Default Unit"),
         description=_(
             "The measurement units for this analysis service' results, e.g. "
             "mg/l, ppm, dB, mV, etc."),
+    )
+)
+
+UnitChoices = RecordsField(
+    "UnitChoices",
+    schemata="Description",
+    type="UnitChoices",
+    subfields=(
+        "unitchoice",
+    ),
+    required_subfields=(
+        "unitchoice",
+    ),
+    subfield_labels={
+        "unitchoice": _("Units"),
+    },
+    subfield_descriptions={
+        "unitchoice": _("Please provide a list of units"),
+    },
+    subfield_types={
+        "unitchoice": "string",
+    },
+    subfield_sizes={
+        "unitchoice": 20,
+    },
+    subfield_validators={
+        "unitchoice": "service_unitchoices_validator",
+    },
+    subfield_maxlength={
+        "unitchoice": 50,
+        "description": 200,
+    },
+    widget=RecordsWidget(
+        label=_("Multiple Unit Selection"),
+        description=_(
+            "Provide a list of units that are suitable for the analysis."
+        ),
     )
 )
 
@@ -687,6 +724,7 @@ schema = BikaSchema.copy() + Schema((
     ProtocolID,
     ScientificName,
     Unit,
+    UnitChoices,
     Precision,
     ExponentialFormatPrecision,
     LowerDetectionLimit,
@@ -753,6 +791,13 @@ class AbstractBaseAnalysis(BaseContent):  # TODO BaseContent?  is really needed?
         unit = self.Schema().getField("Unit").get(self) or ""
         return unit.strip()
 
+    @security.public
+    def getUnitChoices(self):
+        '''Returns the UnitChoices
+        :returns: List of UnitChoices objects
+        '''
+        return self.Schema().getField("UnitChoices").get(self) or ""
+        
     @security.public
     def getDefaultVAT(self):
         """Return default VAT from bika_setup

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -1507,3 +1507,44 @@ class ServiceConditionsValidator(object):
 
 
 validation.register(ServiceConditionsValidator())
+
+class ServiceUnitChoicesValidator(object):
+    """Validate AnalysisService UnitChoices field
+    """
+    implements(IValidator)
+    name = "service_unitchoices_validator"
+
+    def __call__(self, field_value, **kwargs):
+        instance = kwargs["instance"]
+        request = kwargs.get("REQUEST", {})
+        translate = getToolByName(instance, "translation_service").translate
+        field_name = kwargs["field"].getName()
+
+        # This value in request prevents running once per subfield value.
+        # self.name returns the name of the validator. This allows other
+        # subfield validators to be called if defined (eg. in other add-ons)
+        key = "{}-{}-{}".format(self.name, instance.getId(), field_name)
+        if instance.REQUEST.get(key, False):
+            return True
+
+        # Walk through all records set for this records field
+        field_name_value = "{}_value".format(field_name)
+        records = request.get(field_name_value, [])
+        for record in records:
+            # Validate the record
+            msg = self.validate_record(record)
+            if msg:
+                return to_utf8(translate(msg))
+
+        instance.REQUEST[key] = True
+        return True
+
+    def validate_record(self, record):
+        unit_choice = record.get("unitchoice")
+        # Check that the unit choice is a string
+        if not unit_choice:
+                    return _("Validation failed: '{}' is not a string").format(
+                        unit_choice)
+
+
+validation.register(ServiceUnitChoicesValidator())

--- a/src/senaite/core/catalog/analysis_catalog.py
+++ b/src/senaite/core/catalog/analysis_catalog.py
@@ -66,6 +66,7 @@ COLUMNS = BASE_COLUMNS + [
     "getServiceUID",
     "getSubmittedBy",
     "getUnit",
+    "getUnitChoices",
     "getVerificators",
     "isSelfVerificationEnabled",
 ]


### PR DESCRIPTION
+ A list of units can be defined for an analysis service
+ The user can select the units when submitting data.

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
