### PR TITLE
Improve calculations and wildcards

### DIFF
--- a/src/bika/lims/content/abstractanalysis.py
+++ b/src/bika/lims/content/abstractanalysis.py
@@ -582,13 +582,18 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                 try:
                     # we need to quote a string result because of the `eval` below
                     result = '"%s"' % result if str_result else float(str(result))
+                    unc= dependency.getUncertainty()
                     key = dependency.getKeyword()
                     ldl = dependency.getLowerDetectionLimit()
                     udl = dependency.getUpperDetectionLimit()
                     bdl = dependency.isBelowLowerDetectionLimit()
                     adl = dependency.isAboveUpperDetectionLimit()
                     mapping[key] = result
+                    # Pass the key (i.e. NAME) so that other data can be
+                    # retrieved via the API. 
+                    mapping['%s.%s' % (key, 'NAME')] = '"%s"' % key
                     mapping['%s.%s' % (key, 'RESULT')] = result
+                    mapping['%s.%s' % (key, 'UNC')] = unc
                     mapping['%s.%s' % (key, 'LDL')] = api.to_float(ldl, 0.0)
                     mapping['%s.%s' % (key, 'UDL')] = api.to_float(udl, 0.0)
                     mapping['%s.%s' % (key, 'BELOWLDL')] = int(bdl)
@@ -600,7 +605,8 @@ class AbstractAnalysis(AbstractBaseAnalysis):
                 # https://docs.python.org/2.7/library/stdtypes.html?highlight=built#string-formatting-operations
                 converter = "s" if str_result else "f"
                 formula = formula.replace("[" + keyword + "]", "%(" + keyword + ")" + converter)
-
+                # "NAME" is always a string
+                formula = formula.replace("[" + keyword + ".NAME]", "%(" + keyword + ".NAME)" + "s")
 
         # convert any remaining placeholders, e.g. from interims etc.
         # NOTE: we assume remaining values are all floatable!

--- a/src/bika/lims/content/calculation.py
+++ b/src/bika/lims/content/calculation.py
@@ -48,6 +48,7 @@ from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.utils import safe_unicode
 from senaite.core.browser.fields.records import RecordsField
 from zope.interface import implements
+from bika.lims.api import APIError
 
 schema = BikaSchema.copy() + Schema((
 
@@ -126,7 +127,25 @@ schema = BikaSchema.copy() + Schema((
                 "<p>E.g, the calculation for Total Hardness, the total of "
                 "Calcium (ppm) and Magnesium (ppm) ions in water, is entered "
                 "as [Ca] + [Mg], where Ca and MG are the keywords for those "
-                "two Analysis Services.</p>"),
+                "two Analysis Services.</p>"
+                "<p> Wildcards can be included with calcualtions. The following"
+                " wildcards are allowed:"
+                "<ol>"
+                "<li>%(context_uid)s - The wildcard %(context_uid)s in calculation"
+                " formula is automatically replaced by the Unique identifier (UID) of the analysis from which the calculation has been triggered</li>"
+                "<li> .NAME - The wildcard .NAME in calculation formula is automatically replaced by the analysis service name. The wildcard .NAME"
+                " is appended to the analysis service name (e.g. [Ca.NAME]) </li>"
+                "<li> .UNC - The wildcard .UNC in calculation formula is automatically replaced by the uncertainty value for the analysis service." 
+                " The wildcard .UNC is appended to the analysis service name (e.g. [Ca.UNC]) </li>"
+                "<li> .LDL - The wildcard .LDL in calculation formula is automatically replaced by the lower detection limit value defined for the analysis service." 
+                " The wildcard .LDL is appended to the analysis service name (e.g. [Ca.LDL]) </li>"
+                "<li> .UDL - The wildcard .UDL in calculation formula is automatically replaced by the upper detection limit value defined for the analysis service." 
+                " The wildcard .UDL is appended to the analysis service name (e.g. [Ca.UDL]) </li>"
+                "<li> .BELOWLDL - The wildcard .BELOWLDL in calculation formula is automatically replaced by a binary value (i.e, 0 or 1) stating if the result is below"
+                " the lower detection limit.</li>"
+                "<li> .ABOVEUDL - The wildcard .ABOVEUDL in calculation formula is automatically replaced by a binary value (i.e, 0 or 1) stating if the result is above"
+                " the upper detection limit.</li>"
+                ),
         )
     ),
 
@@ -136,7 +155,7 @@ schema = BikaSchema.copy() + Schema((
         subfields=('keyword', 'value'),
         subfield_labels={'keyword': _('Keyword'), 'value': _('Value')},
         subfield_readonly={'keyword': True, 'value': False},
-        subfield_types={'keyword': 'string', 'value': 'float'},
+        subfield_types={'keyword': 'string', 'value': 'string'},
         default=[{'keyword': '', 'value': 0}],
         widget=BikaRecordsWidget(
             label=_("Test Parameters"),
@@ -221,6 +240,19 @@ class Calculation(BaseFolder, HistoryAwareMixin):
             self.getField('Formula').set(self, Formula)
         else:
             keywords = re.compile(r"\[([^.^\]]+)\]").findall(Formula)
+            # get the keywords from the keysandwildcards
+            # evaluate the 'Formula' and obtian both keywords and keysandwildcards
+            keysandwildcards = re.compile(r"\[([^\]]+)\]").findall(Formula)
+            # get keysandwildcards 
+            keysandwildcards = [k for k in keysandwildcards if "." in k]
+            # Split keysandwildcards into [keys,wildcards] list
+            keysandwildcards = [k.split(".", 1) for k in keysandwildcards]
+            # Obtain a list of keys. 
+            keys = [k[0] for k in keysandwildcards]
+            # Add the keys from keysandwildcards to the keywords list. 
+            keywords.extend(keys)  
+            # Remove duplicate keywords from list
+            keywords = list(dict.fromkeys(keywords))
             brains = bsc(portal_type='AnalysisService',
                          getKeyword=keywords)
             services = [brain.getObject() for brain in brains]
@@ -318,17 +350,67 @@ class Calculation(BaseFolder, HistoryAwareMixin):
         # Set default/existing values for InterimField keywords
         for interim in self.getInterimFields():
             keyword = interim.get('keyword')
+            # itermin fields value are always a float
+            val_type_interim = 'float'
             ex = [x.get('value') for x in form_value if
                   x.get('keyword') == keyword]
             params.append({'keyword': keyword,
-                           'value': ex[0] if ex else interim.get('value')})
-        # Set existing/blank values for service keywords
+                           'value': ex[0] if ex else interim.get('value'),
+                           'subfield_type': val_type_interim
+                           })
+
+
+        # Set existing/blank values for service keywords and service keywords with wildcards
+        # allowedwds is a list of allowed keywords.
+        allowedwds = ["LDL", "UDL", "BELOWLDL", "ABOVEUDL","NAME","UNC"]
+        # Get the keywords, interims and keysanwildcards that are defined in the formula        
+        formula_keysandwildcards = re.compile(r"\[([^\]]+)\]").findall(self.getFormula())
         for service in self.getDependentServices():
+            # get the keyword for the dependent services.
             keyword = service.getKeyword()
-            ex = [x.get('value') for x in form_value if
-                  x.get('keyword') == keyword]
-            params.append({'keyword': keyword,
-                           'value': ex[0] if ex else ''})
+            # get the string result for the service
+            str_result = service.getStringResult()
+                        # get the values (e.g. [{'keyword':'example1','value': 'ex1','subfield_type': 'float'},])
+            for val in form_value:
+                # get keyword from the form_value
+                val_keyword=val.get('keyword')       
+                # Check if the form_keyword is in the formula list. This updates param list based on contents of Formula. 
+                if val_keyword in formula_keysandwildcards:
+                    # Get the form value
+                    val_value= val.get('value')
+                    # Define the val type for the result 
+                    val_type_result = 'string' if str_result else 'float'
+                    # Check if keyword is not a wildcard
+                    if "." not in val_keyword:
+                        # check for a key and check that it is in service.getKeyword()
+                        if val_keyword == keyword:
+                            # convert to float if val_type_result is 'float'. 
+                            if val_type_result == 'float':
+                                # convert the record type to float here!!!
+                                try:
+                                    val_value = api.to_float(val_value)
+                                except APIError: 
+                                    val_value = "ERROR: Float required for parameter. '{}' is not floatable. ".format(val_value) 
+                            params.append({'keyword': val_keyword,'value': val_value,'subfield_type':val_type_result})
+
+                    if "." in val_keyword:
+                        default_type_wds = {"LDL": 'float',"UDL":'float', "BELOWLDL":'float', "ABOVEUDL":'float',"NAME":'string', "UNC":'float'}
+                        # Get the key from the wildcard value. 
+                        val_keyword_wds=val.get('keyword').split(".", 1)[0]
+                        wds=val.get('keyword').split(".", 1)[1]
+                        # define the result type
+                        val_type_result = default_type_wds[wds]
+                        # convert to float if val_type_result is 'float'. 
+                        if val_type_result == 'float':
+                            try:
+                                val_value = api.to_float(val_value)
+                            except APIError: 
+                                val_value = "ERROR: Float required for parameter. '{}' is not floatable. ".format(val_value) 
+                        # check for a key and check that it is in service.getKeyword()
+                        if val_keyword_wds == keyword:
+                            if wds in allowedwds:
+                                params.append({'keyword': val_keyword,'value': val_value,'subfield_type':val_type_result})
+
         self.Schema().getField('TestParameters').set(self, params)
 
     # noinspection PyUnusedLocal
@@ -338,6 +420,7 @@ class Calculation(BaseFolder, HistoryAwareMixin):
         """
         # Create mapping from TestParameters
         mapping = {x['keyword']: x['value'] for x in self.getTestParameters()}
+        type_dict= {x['keyword']: x['subfield_type'] for x in self.getTestParameters()}
         # Gather up and parse formula
         formula = self.getMinifiedFormula()
         test_result_field = self.Schema().getField('TestResult')
@@ -346,11 +429,27 @@ class Calculation(BaseFolder, HistoryAwareMixin):
         if not formula:
             return test_result_field.set(self, "")
 
-        formula = formula.replace('[', '{').replace(']', '}').replace('  ', '')
+        for keyword in mapping.keys():
+            if type_dict[keyword] ==  'string':
+                converter = "s"
+                # we need to quote a string result because of the `eval` below
+                mapping[keyword]='"%s"' % mapping[keyword]
+            else:
+                converter = "f"
+
+            formula = formula.replace("[" + keyword + "]", "%(" + keyword + ")" + converter)
+            # convert any remaining placeholders, e.g. from interims etc.
+        # NOTE: we assume remaining values are all floatable!
+        formula = formula.replace("[", "%(").replace("]", ")f")
+
         result = 'Failure'
 
         try:
-            formula = formula.format(**mapping)
+            formula = eval("'%s'%%mapping" % formula,
+                           {"__builtins__": None,
+                            'math': math,
+                            'context': self},
+                           {'mapping': mapping})            
             result = eval(formula, self._getGlobals())
         except TypeError as e:
             # non-numeric arguments in interim mapping?

--- a/src/bika/lims/validators.py
+++ b/src/bika/lims/validators.py
@@ -495,19 +495,29 @@ class FormulaValidator:
                 return to_utf8(translate(msg))
 
         # Allow to use Wildcards, LDL and UDL values in calculations
-        allowedwds = ["LDL", "UDL", "BELOWLDL", "ABOVEUDL"]
+        allowedwds = ["LDL", "UDL", "BELOWLDL", "ABOVEUDL","NAME","UNC"]
         keysandwildcards = re.compile(r"\[([^\]]+)\]").findall(value)
         keysandwildcards = [k for k in keysandwildcards if "." in k]
         keysandwildcards = [k.split(".", 1) for k in keysandwildcards]
-        errwilds = [k[1] for k in keysandwildcards if k[0] not in keywords]
-        if len(errwilds) > 0:
-            msg = _(
-                "Wildcards for interims are not allowed: ${wildcards}",
-                mapping={
-                    "wildcards": safe_unicode(", ".join(errwilds))
-                })
-            return to_utf8(translate(msg))
-
+       
+        """
+        Check if interim_fields include a wildcard
+        Get the key form the keysandwildcards and check if its in the dep_service.
+        If not raise an eror that interim_fields cannot include wildcards
+        """
+        #get keys from keysandwildcards
+        keys=[key[0] for key in keysandwildcards]
+        for num, key in enumerate(keys):
+            # Check if the service keyword exists and is active.
+            dep_service = catalog(getKeyword=key, is_active=True)
+            if not dep_service:
+                msg = _(
+                    "Validation failed: Keyword '${key}' is invalid. Wildcards for interims are not allowed: ${keyword}",
+                    mapping={
+                        'key': safe_unicode(key),
+                        'keyword': safe_unicode(keysandwildcards[num])
+                    })
+                return to_utf8(translate(msg))
         wildcards = [k[1] for k in keysandwildcards if k[0] in keywords]
         wildcards = [wd for wd in wildcards if wd not in allowedwds]
         if len(wildcards) > 0:


### PR DESCRIPTION
Improvements:
+ string values can be inserted when calculating wildcards
+ wildcards can be used independently of the analysis service keyword. Previously it was required that the analysis service keyword be defined elsewhere in the calculation.
+ includes '.UNC' and '.NAME' wildcards. '.UNC' passes the uncertainty. ',NAME' passes the analysis services keyword to the calculation.
+ updated blob to include information about wildcards

## Description of the issue/feature this PR addresses

Linked issue: https://github.com/senaite/senaite.core/issues/

## Current behavior before PR

## Desired behavior after PR is merged

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1]
and [Plone's Python styleguide][2] standards.

[1]: https://www.python.org/dev/peps/pep-0008
[2]: https://docs.plone.org/develop/styleguide/python.html
